### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3.8 -m pip install setuptools && python3.8 -m pip install pyte && python3.8 -m pip install discord.py && python3.8 bashbot.py"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![BashBot](https://i.imgur.com/oHESoVW.png)
 
 ![Python 3.5](https://img.shields.io/badge/python-3.5-orange.svg) ![Discord.py](https://img.shields.io/badge/discord.py-0.16.11-green.svg) ![Discord.py](https://img.shields.io/badge/pyte-0.7.0_dev-blue.svg)
+[![Run on Repl.it](https://repl.it/badge/github/Adikso/BashBot)](https://repl.it/github/Adikso/BashBot)
 
 BashBot is a Discord bot that provides terminal access via chat.
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@vityavv/BashBot).